### PR TITLE
Fix API call countdown interval reuse

### DIFF
--- a/js/block.js
+++ b/js/block.js
@@ -8,6 +8,7 @@ const updateInterval = 21000;
 const defaultTimeBetweenBlocks = 10;
 let lastBlock = false;
 let countdownInterval;
+let apiCallCountdownInterval;
 
 function fetchData() {
   fetch('https://api.blockchain.info/stats')
@@ -66,11 +67,16 @@ function fetchData() {
 function updateApiCallCountdown() {
   let countdown = updateInterval / 1000;
   const countdownElement = document.getElementById('updateIn');
-  const intervalId = setInterval(() => {
+
+  if (apiCallCountdownInterval) {
+    clearInterval(apiCallCountdownInterval);
+  }
+
+  apiCallCountdownInterval = setInterval(() => {
     countdown--;
     countdownElement.textContent = countdown;
     if (countdown <= 0) {
-      clearInterval(intervalId);
+      clearInterval(apiCallCountdownInterval);
       countdownElement.textContent = updateInterval / 1000;
     }
   }, 1000);


### PR DESCRIPTION
## Summary
- ensure API call countdown clears previous interval before starting a new one

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68400f549f4c8327a3a0776dd3c0b4e4