### PR TITLE
Fix comment syntax in contact form

### DIFF
--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -18,7 +18,8 @@
                 </div>
             </div>
 
-            <!--div class="row">
+            <!--
+            <div class="row">
                 <div class="col-lg-12">
                     <form name="sentMessage" id="contactForm" novalidate>
                         <div class="row">
@@ -50,6 +51,7 @@
                         </div>
                     </form>
                 </div>
-            </div-->
+            </div>
+            -->
         </div>
     </section>


### PR DESCRIPTION
## Summary
- fix broken HTML comment markers around the contact form

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68400e3088f48327af583ae099073d69