### PR TITLE
Fix typos in hex_to_rgb plugin comments

### DIFF
--- a/_plugins/hex_to_rgb.rb
+++ b/_plugins/hex_to_rgb.rb
@@ -12,9 +12,9 @@
 #   {{ "0a0b0c" | hex_to_rgb }}
 #   # => [10, 11, 12]
 #
-# hexval - string of valid hexidecimal characters
+# hexval - string of valid hexadecimal characters
 #
-# Returns an array of decimal values for the parse hex characters
+# Returns an array of decimal values for the parsed hex characters
 #
 
 module Jekyll


### PR DESCRIPTION
## Summary
- update comments in `_plugins/hex_to_rgb.rb`

## Testing
- `bundle install --jobs 4 --retry 3`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68401967927883279797c453d17b8e6e