### PR TITLE
Add MiniTest for hex_to_rgb

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ bundle exec jekyll serve
 
 ### Docs
 For more details, visit the jekyll [documentation](http://jekyllrb.com/) website.
+
+### Tests
+Run the unit tests with Ruby:
+```
+ruby -Itest test/test_hex_to_rgb.rb
+```

--- a/test/test_hex_to_rgb.rb
+++ b/test/test_hex_to_rgb.rb
@@ -1,0 +1,17 @@
+require 'minitest/autorun'
+require 'liquid'
+require_relative '../_plugins/hex_to_rgb'
+
+class HexToRGBTest < Minitest::Test
+  def setup
+    @filter = Object.new.extend(Jekyll::HexToRGB)
+  end
+
+  def test_even_length
+    assert_equal [170, 187, 204], @filter.hex_to_rgb('aabbcc')
+  end
+
+  def test_odd_length
+    assert_equal [170, 187, 204], @filter.hex_to_rgb('abc')
+  end
+end


### PR DESCRIPTION
## Summary
- add MiniTest for the `hex_to_rgb` plugin
- document how to run the tests

## Testing
- `ruby -Itest test/test_hex_to_rgb.rb`

------
https://chatgpt.com/codex/tasks/task_e_68401972ae888327ae4ea24bb368c6c3